### PR TITLE
[servicemanager] Declare Alert before SMOutgoingMessages

### DIFF
--- a/proto/servicemanager/v4/servicemanager.proto
+++ b/proto/servicemanager/v4/servicemanager.proto
@@ -175,6 +175,20 @@ message ImageContent {
     bytes  data          = 5;
 }
 
+message Alert {
+    google.protobuf.Timestamp timestamp = 1;
+    string                    tag       = 2;
+    oneof                     AlertItem {
+        SystemQuotaAlert      system_quota_alert      = 3;
+        InstanceQuotaAlert    instance_quota_alert    = 4;
+        ResourceValidateAlert resource_validate_alert = 5;
+        DeviceAllocateAlert   device_allocate_alert   = 6;
+        SystemAlert           system_alert            = 7;
+        CoreAlert             core_alert              = 8;
+        InstanceAlert         instance_alert          = 9;
+    }
+}
+
 message SMOutgoingMessages {
     oneof SMOutgoingMessage {
         NodeConfigStatus      node_config_status      = 2;
@@ -269,20 +283,6 @@ message PartitionUsage {
 message InstanceMonitoring {
     common.v1.InstanceIdent instance        = 1;
     MonitoringData          monitoring_data = 2;
-}
-
-message Alert {
-    google.protobuf.Timestamp timestamp = 1;
-    string                    tag       = 2;
-    oneof                     AlertItem {
-        SystemQuotaAlert      system_quota_alert      = 3;
-        InstanceQuotaAlert    instance_quota_alert    = 4;
-        ResourceValidateAlert resource_validate_alert = 5;
-        DeviceAllocateAlert   device_allocate_alert   = 6;
-        SystemAlert           system_alert            = 7;
-        CoreAlert             core_alert              = 8;
-        InstanceAlert         instance_alert          = 9;
-    }
 }
 
 message ImageContentRequest {


### PR DESCRIPTION
This PR fixes nanopb compilation issue:

In file included from /home/mykhailo_lohvynenko/projects/aos/aos_zephyr_sdk/aos_core_zephyr/build/proto/servicemanager/v4/servicemanager.pb.c:4:
/home/mykhailo_lohvynenko/projects/aos/aos_zephyr_sdk/aos_core_zephyr/build/proto/servicemanager/v4/servicemanager.pb.h:1267:524: error: invalid application of ‘sizeof’ to incomplete type ‘union servicemanager_v4_Alert_AlertItem_size_union’
 1267 | union servicemanager_v4_SMOutgoingMessages_SMOutgoingMessage_size_union {char f2[(178 + common_v1_ErrorInfo_size)]; char f3[(1126 + 16*common_v1_InstanceIdent_size + 16*common_v1_ErrorInfo_size)]; char f4[(1126 + 16*common_v1_InstanceIdent_size + 16*common_v1_ErrorInfo_size)]; char f5[(8572 + 16*8*common_v1_ErrorInfo_size + common_v1_ErrorInfo_size)]; char f6[(1145 + common_v1_ErrorInfo_size)]; char f7[(14835 + 16*common_v1_InstanceIdent_size)]; char f8[(14835 + 16*common_v1_InstanceIdent_size)]; char f9[(72 + sizeof(union servicemanager_v4_Alert_AlertItem_size_union))]; char f0[291];};
 
 