### PR TITLE
Feature add libs

### DIFF
--- a/.cmake-format
+++ b/.cmake-format
@@ -1,0 +1,7 @@
+format:
+  line_width: 120
+  tab_size: 4
+  dangle_parens: true
+
+markup:
+  enable_markup: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,58 @@
+#
+# Copyright (C) 2024 Renesas Electronics Corporation.
+# Copyright (C) 2024 EPAM Systems, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.19)
+
+# ##############################################################################
+# Generate gRPC stubs
+# ##############################################################################
+
+project(aos_core_api)
+
+# ##############################################################################
+# Options
+# ##############################################################################
+
+option(WITH_IAM_API "build core api iam lib" ON)
+option(WITH_SM_API "build core api sm lib" OFF)
+
+message(STATUS)
+message(STATUS "${CMAKE_PROJECT_NAME} configuration:")
+message(STATUS "WITH_IAM_API            = ${WITH_IAM_API}")
+message(STATUS "WITH_SM_API             = ${WITH_SM_API}")
+
+# ##############################################################################
+# Compiler flags
+# ##############################################################################
+
+add_compile_options(-fPIC -Wall -Werror -Wextra -Wpedantic)
+set(CMAKE_CXX_STANDARD 17)
+
+# ##############################################################################
+# Dependencies
+# ##############################################################################
+
+find_package(gRPC CONFIG REQUIRED)
+find_package(Protobuf REQUIRED)
+
+set(PROTO_DST_DIR "${CMAKE_CURRENT_BINARY_DIR}/gen")
+set(PROTO_SRC_DIR "${CMAKE_CURRENT_LIST_DIR}/proto")
+set(GENERATE_EXTENSIONS ".grpc.pb.h" ".grpc.pb.cc")
+
+file(MAKE_DIRECTORY ${PROTO_DST_DIR})
+
+if(CMAKE_CROSSCOMPILING)
+    find_program(_GRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin)
+else()
+    set(_GRPC_CPP_PLUGIN_EXECUTABLE $<TARGET_FILE:gRPC::grpc_cpp_plugin>)
+endif()
+
+# ##############################################################################
+# Targets
+# ##############################################################################
+
+add_subdirectory(proto)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,11 +17,13 @@ project(aos_core_api)
 # Options
 # ##############################################################################
 
+option(WITH_AOS_PROTOCOL "build aos protocol lib" OFF)
 option(WITH_IAM_API "build core api iam lib" ON)
 option(WITH_SM_API "build core api sm lib" OFF)
 
 message(STATUS)
 message(STATUS "${CMAKE_PROJECT_NAME} configuration:")
+message(STATUS "WITH_AOS_PROTOCOL       = ${WITH_AOS_PROTOCOL}")
 message(STATUS "WITH_IAM_API            = ${WITH_IAM_API}")
 message(STATUS "WITH_SM_API             = ${WITH_SM_API}")
 
@@ -55,4 +57,5 @@ endif()
 # Targets
 # ##############################################################################
 
+add_subdirectory(aosprotocol)
 add_subdirectory(proto)

--- a/aosprotocol/CMakeLists.txt
+++ b/aosprotocol/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Copyright (C) 2024 Renesas Electronics Corporation.
+# Copyright (C) 2024 EPAM Systems, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# ######################################################################################################################
+# Targets
+# ######################################################################################################################
+
+if(WITH_AOS_PROTOCOL)
+    add_library(aosprotocol INTERFACE)
+
+    target_include_directories(aosprotocol INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+endif()

--- a/proto/CMakeLists.txt
+++ b/proto/CMakeLists.txt
@@ -1,0 +1,55 @@
+#
+# Copyright (C) 2024 Renesas Electronics Corporation.
+# Copyright (C) 2024 EPAM Systems, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# ######################################################################################################################
+# Functions
+# ######################################################################################################################
+
+function(create_core_api_lib TARGET_NAME PROTO_FILES)
+    message(STATUS "Generating ${TARGET_NAME} target")
+
+    add_library(${TARGET_NAME} OBJECT ${PROTO_FILES})
+    target_link_libraries(${TARGET_NAME} PUBLIC protobuf::libprotobuf gRPC::grpc++)
+    target_include_directories(${TARGET_NAME} PUBLIC "$<BUILD_INTERFACE:${PROTO_DST_DIR}>")
+
+    protobuf_generate(TARGET ${TARGET_NAME} IMPORT_DIRS ${PROTO_SRC_DIR} PROTOC_OUT_DIR "${PROTO_DST_DIR}")
+
+    protobuf_generate(
+        TARGET
+        ${TARGET_NAME}
+        LANGUAGE
+        grpc
+        GENERATE_EXTENSIONS
+        ${GENERATE_EXTENSIONS}
+        PLUGIN
+        "protoc-gen-grpc=${_GRPC_CPP_PLUGIN_EXECUTABLE}"
+        IMPORT_DIRS
+        ${PROTO_SRC_DIR}
+        PROTOC_OUT_DIR
+        "${PROTO_DST_DIR}"
+    )
+endfunction()
+
+# ######################################################################################################################
+# Targets
+# ######################################################################################################################
+
+if(WITH_IAM_API)
+    set(IAM_PROTO_FILES "${PROTO_SRC_DIR}/common/v1/common.proto" "${PROTO_SRC_DIR}/iamanager/v5/iamanager.proto"
+                        "${PROTO_SRC_DIR}/iamanager/version.proto"
+    )
+
+    create_core_api_lib(aoscoreapi-gen-iam "${IAM_PROTO_FILES}")
+endif()
+
+if(WITH_SM_API)
+    set(SM_PROTO_FILES "${PROTO_SRC_DIR}/common/v1/common.proto"
+                       "${PROTO_SRC_DIR}/servicemanager/v4/servicemanager.proto"
+    )
+
+    create_core_api_lib(aoscoreapi-gen-sm "${SM_PROTO_FILES}")
+endif()


### PR DESCRIPTION
Approach with cmake per lib works fine on host build, but fails on yocto. 
Yocto generates paths like "build/gen/proto/iamanager/iamager.*"
Host generates  paths like "build/gen/iamanager/iamager.*"


Approach with single cmake in the root folder for protos works fine.