### PR TITLE
[sm] Rename InstanceStatus error_info field to error

### DIFF
--- a/proto/servicemanager/v4/servicemanager.proto
+++ b/proto/servicemanager/v4/servicemanager.proto
@@ -229,7 +229,7 @@ message InstanceStatus {
     common.v1.InstanceIdent instance        = 1;
     string                  service_version = 2;
     string                  run_state       = 3;
-    common.v1.ErrorInfo     error_info      = 4;
+    common.v1.ErrorInfo     error           = 4;
 }
 
 message OverrideEnvVarStatus {


### PR DESCRIPTION
All error info fields are named as error in other places. Rename this field as well to use same template to fill proto instance status.